### PR TITLE
Fix blind skipping, expose skip rewards, and improve gameplay guidance

### DIFF
--- a/mcp/src/prompts/strategy.md
+++ b/mcp/src/prompts/strategy.md
@@ -18,6 +18,14 @@ Use `balatro_list_game_entities` to read entity prototypes from the running game
 - Shared bridge errors: `GAME_NOT_RUNNING` means no Balatro instance is connected, `INSTANCE_BUSY` means another MCP client owns the bridge, and `PROTOCOL_MISMATCH` means the TypeScript server and Balatro mod versions are incompatible. Treat these as hard stops — do not fabricate state or outcomes.
 - Do not replay an action tool call unless the bridge explicitly reports it was lost or failed.
 
+### Tactical Checks
+
+- Before every hand, inspect the active Blind's restrictions. Satisfy hard constraints explicitly: The Psychic requires exactly five selected cards (non-scoring kickers are allowed), The Mouth locks the first poker-hand type, and The Eye forbids repeating a poker-hand type.
+- Use discards to build toward the run's strongest Joker-supported hand instead of automatically playing the best naked hand currently visible. Preserve useful pairs, triples, enhanced cards, and sealed cards; with discards remaining, draw toward the supported hand when its expected Joker-adjusted score or scaling value beats the immediate play.
+- Do not routinely finish a difficult round with all discards unused. Red Deck's extra discard is a resource for finding the build-defining hand, especially when the current hand cannot meet the Blind in the remaining plays.
+- During blind selection, inspect `blind_selection` and its `skip_reward` before deciding. Boss Blinds cannot be skipped. Skip Small or Big blinds only when the tag's concrete value and tempo exceed the lost blind reward, shop access, and scaling opportunities.
+- Joker order is gameplay-relevant because scoring resolves left to right. In general, put additive Chips/Mult before xMult, and position Blueprint, Brainstorm, or other copy effects against the intended target before playing.
+
 ### Reasoning Style
 
 State the phase, blind, money, and decisive constraints before suggesting a move. Prefer concrete, citable rules ("Boss Blinds cannot be skipped") over generic advice. When tradeoffs exist, name both options and the rule that breaks the tie.

--- a/mcp/src/prompts/strategy.ts
+++ b/mcp/src/prompts/strategy.ts
@@ -13,6 +13,7 @@ import INSTRUCTION_BLOCK from "./strategy.md" with { type: "text" };
 
 const PROMPT_NAME = "balatro_strategy_context";
 
+
 export function registerStrategyPrompt(server: McpServer): void {
   server.registerPrompt(
     PROMPT_NAME,

--- a/mcp/src/tools/booster.ts
+++ b/mcp/src/tools/booster.ts
@@ -27,7 +27,7 @@ const selectBoosterCardSchema = z
     targets: z
       .array(cardIdSchema)
       .optional()
-      .describe("Optional array of target card IDs for consumables that operate on specific cards (e.g. Tarots that enhance hand cards). Omit for cards that take no targets."),
+      .describe("Ordered target hand card IDs. Required for targeted consumables; for Death, pass [source_card_id, destination_card_id] so the source becomes a copy of the destination. Omit only for cards that take no targets."),
   })
   .strict();
 

--- a/mcp/src/tools/cardActions.ts
+++ b/mcp/src/tools/cardActions.ts
@@ -15,6 +15,10 @@ const useConsumableSchema = z
     card_id: z
       .union([z.string(), z.number().int()])
       .describe("The ID of the consumable card to use from your consumable slots."),
+    targets: z
+      .array(cardIdSchema)
+      .optional()
+      .describe("Ordered target hand card IDs. Required for targeted consumables; for Death, pass [source_card_id, destination_card_id]."),
   })
   .strict();
 
@@ -37,10 +41,11 @@ async function executeCardAction(
   deps: Deps,
   kind: "use_consumable" | "sell_card",
   cardId: string,
+  targets?: string[],
 ) {
   let response;
   try {
-    const seq = await deps.bridgeClient.sendCommand({ kind, args: { card_id: cardId } });
+    const seq = await deps.bridgeClient.sendCommand({ kind, args: { card_id: cardId, targets } });
     response = await deps.bridgeClient.awaitResponse(seq);
   } catch (err) {
     if (err instanceof BridgeError) {
@@ -72,7 +77,8 @@ export function registerCardActionTools(server: McpServer, deps: Deps): void {
       annotations: ANNOTATIONS,
     },
     async (args) => {
-      const envelope = await executeCardAction(deps, "use_consumable", normalizeCardId(args.card_id));
+      const targets = args.targets ? normalizeCardIds(args.targets) : undefined;
+      const envelope = await executeCardAction(deps, "use_consumable", normalizeCardId(args.card_id), targets);
       return { ...envelope };
     },
   );

--- a/mcp/src/tools/reorderJokers.ts
+++ b/mcp/src/tools/reorderJokers.ts
@@ -16,7 +16,7 @@ const reorderJokersSchema = z
       .min(0)
       .max(50)
       .describe(
-        "Array of Joker card IDs in the desired left-to-right display order. Each ID must reference a Joker currently in the player's Joker area. The array should contain exactly the Jokers held to fully reorder them.",
+        "Array of Joker card IDs in the desired left-to-right scoring order. Each ID must reference a Joker currently in the player's Joker area. The array should contain exactly the Jokers held to fully reorder them.",
       ),
   })
   .strict();

--- a/mods/balatro_mcp/src/actions.lua
+++ b/mods/balatro_mcp/src/actions.lua
@@ -1,4 +1,4 @@
---- actions.lua — Action dispatcher for the Balatro MCP bridge.
+--- actions.lua ? Action dispatcher for the Balatro MCP bridge.
 -- Maps each command kind to the correct Balatro G.FUNCS call with phase guards
 -- and sticker rules. Defense-in-depth: re-checks G.STATE before every action.
 
@@ -341,20 +341,37 @@ handlers.skip_blind = function(args)
   local phase_err = check_phase({ S("BLIND_SELECT") })
   if phase_err then return phase_err end
 
-  -- Boss blind cannot be skipped
-  if G.GAME and G.GAME.blind and G.GAME.blind.boss then
-    -- Check if this is the final ante in non-endless mode
-    if G.GAME.round_resets and G.GAME.round_resets.ante and G.GAME.round_resets.ante >= 8
-        and not (G.GAME.round_resets.ante > 8) then
-      -- Only block if it's actually the boss blind being presented
-    end
+  local round_resets = G.GAME and G.GAME.round_resets
+  local blind_key = G.GAME and G.GAME.blind_on_deck
+  if blind_key ~= "Small" and blind_key ~= "Big" then
+    return err("INVALID_TARGET", "Only Small and Big blinds can be skipped; blind_on_deck=" .. tostring(blind_key))
   end
 
-  if G.FUNCS and G.FUNCS.skip_blind then
-    G.FUNCS.skip_blind()
+  local tag_key = round_resets and round_resets.blind_tags and round_resets.blind_tags[blind_key]
+  if not tag_key then
+    return err("INVALID_TARGET", "No skip tag is available for blind slot: " .. tostring(blind_key))
   end
 
-  return ok({ skipped = true })
+  local blind_ui = G.blind_select_opts and G.blind_select_opts[string.lower(blind_key)]
+  local select_button = blind_ui and blind_ui.get_UIE_by_ID and blind_ui:get_UIE_by_ID("select_blind_button")
+  local tag_container = select_button and select_button.UIBox and select_button.UIBox.get_UIE_by_ID
+      and select_button.UIBox:get_UIE_by_ID("tag_container")
+  if not select_button or not select_button.UIBox or not tag_container then
+    return err("INVALID_TARGET", "Blind skip UI is not ready for slot: " .. tostring(blind_key))
+  end
+
+  if not G.FUNCS or not G.FUNCS.skip_blind then
+    return err("INVALID_TARGET", "Blind skip callback is unavailable")
+  end
+
+  -- The base-game callback reads e.UIBox to resolve the tag reward.
+  G.FUNCS.skip_blind(select_button)
+
+  return ok({
+    skipped = true,
+    blind = string.lower(blind_key),
+    tag = tag_key,
+  })
 end
 
 ---------------------------------------------------------------------------

--- a/mods/balatro_mcp/src/actions.lua
+++ b/mods/balatro_mcp/src/actions.lua
@@ -1,4 +1,4 @@
---- actions.lua ? Action dispatcher for the Balatro MCP bridge.
+--- actions.lua — Action dispatcher for the Balatro MCP bridge.
 -- Maps each command kind to the correct Balatro G.FUNCS call with phase guards
 -- and sticker rules. Defense-in-depth: re-checks G.STATE before every action.
 
@@ -197,6 +197,37 @@ end
 
 local function find_card_in_pack(card_id)
   return find_card_in(G.pack_cards, card_id)
+end
+
+local function prepare_consumable_targets(card, args)
+  local target_card_ids = args.target_card_ids or args.targets or {}
+  if type(target_card_ids) ~= "table" then
+    return err("INVALID_TARGET", "targets must be an array of hand card IDs")
+  end
+
+  -- Do not reuse highlights left by a previous play or discard.
+  if G.hand and G.hand.unhighlight_all then
+    G.hand:unhighlight_all()
+  end
+
+  for _, target_id in ipairs(target_card_ids) do
+    local target = find_card_in_hand(target_id)
+    if not target then
+      return err("INVALID_TARGET", "Target card not found in hand: " .. tostring(target_id))
+    end
+    if G.hand and G.hand.add_to_highlighted then
+      G.hand:add_to_highlighted(target)
+    end
+  end
+
+  -- Balatro owns the exact target-count rules for each consumable. Validate
+  -- only after the requested cards have been highlighted.
+  if card.can_use_consumeable and not card:can_use_consumeable() then
+    local hint = #target_card_ids == 0 and "; provide targets for targeted consumables" or ""
+    return err("INVALID_TARGET", "Consumable cannot be used with the supplied targets" .. hint)
+  end
+
+  return nil
 end
 
 ---------------------------------------------------------------------------
@@ -591,28 +622,8 @@ handlers.use_consumable = function(args)
     return err("INVALID_TARGET", "Consumable not found: " .. tostring(card_id))
   end
 
-  -- Check can_use_consumeable
-  if card.can_use_consumeable and not card:can_use_consumeable() then
-    return err("INVALID_TARGET", "Consumable cannot be used in current context")
-  end
-
-  -- If target_card_ids provided, highlight those cards first
-  if args.target_card_ids and type(args.target_card_ids) == "table" and #args.target_card_ids > 0 then
-    -- Unhighlight all first
-    if G.hand and G.hand.unhighlight_all then
-      G.hand:unhighlight_all()
-    end
-    -- Highlight targets
-    for _, tid in ipairs(args.target_card_ids) do
-      local target = find_card_in_hand(tid)
-      if not target then
-        return err("INVALID_TARGET", "Target card not found in hand: " .. tostring(tid))
-      end
-      if G.hand and G.hand.add_to_highlighted then
-        G.hand:add_to_highlighted(target)
-      end
-    end
-  end
+  local target_err = prepare_consumable_targets(card, args)
+  if target_err then return target_err end
 
   -- Use the consumable
   if G.FUNCS and G.FUNCS.use_card then
@@ -771,26 +782,8 @@ handlers.buy_and_use_card = function(args)
     return err("INSUFFICIENT_FUNDS", "Cannot afford card (cost=" .. tostring(cost) .. ", available=" .. tostring(available_funds()) .. ")")
   end
 
-  -- Check can_use
-  if card.can_use_consumeable and not card:can_use_consumeable() then
-    return err("INVALID_TARGET", "Consumable cannot be used in current context")
-  end
-
-  -- If target_card_ids provided, highlight those cards first
-  if args.target_card_ids and type(args.target_card_ids) == "table" and #args.target_card_ids > 0 then
-    if G.hand and G.hand.unhighlight_all then
-      G.hand:unhighlight_all()
-    end
-    for _, tid in ipairs(args.target_card_ids) do
-      local target = find_card_in_hand(tid)
-      if not target then
-        return err("INVALID_TARGET", "Target card not found in hand: " .. tostring(tid))
-      end
-      if G.hand and G.hand.add_to_highlighted then
-        G.hand:add_to_highlighted(target)
-      end
-    end
-  end
+  local target_err = prepare_consumable_targets(card, args)
+  if target_err then return target_err end
 
   -- Native Balatro buy-and-use is a single delayed buy_from_shop flow. Passing
   -- id='buy_and_use' makes buy_from_shop skip slot placement and call use_card
@@ -926,6 +919,12 @@ handlers.select_booster_card = function(args)
     return err("INVALID_TARGET", "Card not found in pack: " .. tostring(card_id))
   end
 
+  local set = card.config and card.config.center and card.config.center.set
+  if set == "Tarot" or set == "Planet" or set == "Spectral" then
+    local target_err = prepare_consumable_targets(card, args)
+    if target_err then return target_err end
+  end
+
   -- Check destination slots
   if card.config and card.config.center then
     local set = card.config.center.set
@@ -934,12 +933,6 @@ handlers.select_booster_card = function(args)
       local joker_limit = G.jokers and G.jokers.config and G.jokers.config.card_limit or 5
       if joker_count >= joker_limit then
         return err("SLOTS_FULL", "No available joker slots")
-      end
-    elseif set == "Tarot" or set == "Planet" or set == "Spectral" then
-      local cons_count = G.consumeables and G.consumeables.cards and #G.consumeables.cards or 0
-      local cons_limit = G.consumeables and G.consumeables.config and G.consumeables.config.card_limit or 2
-      if cons_count >= cons_limit then
-        return err("SLOTS_FULL", "No available consumable slots")
       end
     end
   end

--- a/mods/balatro_mcp/src/state.lua
+++ b/mods/balatro_mcp/src/state.lua
@@ -434,12 +434,18 @@ local function compute_legal_actions()
     local blind_key = G.GAME and G.GAME.blind_on_deck
     local blind_ui = blind_key and G.blind_select_opts and G.blind_select_opts[string.lower(blind_key)]
     local select_button = blind_ui and blind_ui.get_UIE_by_ID and blind_ui:get_UIE_by_ID('select_blind_button')
+    local round_resets = G.GAME and G.GAME.round_resets
     if G.GAME and G.GAME.round_resets and G.GAME.round_resets.blind_choices
         and (blind_key == 'Small' or blind_key == 'Big' or blind_key == 'Boss')
         and G.GAME.round_resets.blind_choices[blind_key]
         and select_button and select_button.UIBox and select_button.config and select_button.config.ref_table then
       actions[#actions + 1] = 'select_blind'
-      actions[#actions + 1] = 'skip_blind'
+      local tag_key = round_resets.blind_tags and round_resets.blind_tags[blind_key]
+      local tag_container = select_button.UIBox.get_UIE_by_ID
+          and select_button.UIBox:get_UIE_by_ID('tag_container')
+      if (blind_key == 'Small' or blind_key == 'Big') and tag_key and tag_container then
+        actions[#actions + 1] = 'skip_blind'
+      end
     end
     -- Reroll in blind select requires Retcon voucher
     if G.GAME and G.GAME.used_vouchers and G.GAME.used_vouchers.v_retcon then

--- a/mods/balatro_mcp/src/state.lua
+++ b/mods/balatro_mcp/src/state.lua
@@ -103,6 +103,22 @@ do
   end
 end
 
+local function compact_table(value, depth)
+  if type(value) ~= 'table' or depth <= 0 then return nil end
+  local out = {}
+  for key, item in pairs(value) do
+    if type(key) == 'string' or type(key) == 'number' then
+      local item_type = type(item)
+      if item_type == 'string' or item_type == 'number' or item_type == 'boolean' then
+        out[key] = item
+      elseif item_type == 'table' then
+        out[key] = compact_table(item, depth - 1)
+      end
+    end
+  end
+  return next(out) and out or nil
+end
+
 -- Card serialization helpers
 -------------------------------------------------------------------------------
 
@@ -657,6 +673,63 @@ local function snapshot_tags()
   return tags
 end
 
+local function snapshot_skip_reward(tag_key, blind_key)
+  local tag = G.P_TAGS and G.P_TAGS[tag_key]
+  local config = tag and tag.config or {}
+  local reward = {
+    entity_id = tag_key,
+    name = tag and tag.name or tag_key,
+    config = compact_table(config, 3),
+  }
+
+  if tag_key == 'tag_investment' then
+    reward.dollars = config.dollars
+  elseif tag_key == 'tag_handy' then
+    reward.dollars = (config.dollars_per_hand or 0) * (G.GAME.hands_played or 0)
+  elseif tag_key == 'tag_garbage' then
+    reward.dollars = (config.dollars_per_discard or 0) * (G.GAME.unused_discards or 0)
+  elseif tag_key == 'tag_skip' then
+    reward.dollars = (config.skip_bonus or 0) * ((G.GAME.skips or 0) + 1)
+  elseif tag_key == 'tag_economy' then
+    reward.dollars = math.min(config.max or 0, math.max(0, G.GAME.dollars or 0))
+  elseif tag_key == 'tag_orbital' then
+    local ante = G.GAME.round_resets and G.GAME.round_resets.ante
+    local choices = G.GAME.orbital_choices
+    reward.poker_hand = ante and choices and choices[ante] and choices[ante][blind_key] or nil
+  end
+
+  return reward
+end
+
+local function snapshot_blind_selection()
+  local round_resets = G and G.GAME and G.GAME.round_resets
+  if not round_resets or not round_resets.blind_choices then return nil end
+
+  local selection = { current = G.GAME.blind_on_deck }
+  local has_choice = false
+  for _, blind_key in ipairs({ 'Small', 'Big', 'Boss' }) do
+    local blind_id = round_resets.blind_choices[blind_key]
+    if blind_id then
+      local blind = G.P_BLINDS and G.P_BLINDS[blind_id]
+      local choice = {
+        blind_id = blind_id,
+        name = blind and blind.name or blind_id,
+        state = round_resets.blind_states and round_resets.blind_states[blind_key] or nil,
+      }
+
+      local tag_key = round_resets.blind_tags and round_resets.blind_tags[blind_key]
+      if (blind_key == 'Small' or blind_key == 'Big') and tag_key then
+        choice.skip_reward = snapshot_skip_reward(tag_key, blind_key)
+      end
+
+      selection[blind_key] = choice
+      has_choice = true
+    end
+  end
+
+  return has_choice and selection or nil
+end
+
 -------------------------------------------------------------------------------
 -- Hand levels snapshot
 -------------------------------------------------------------------------------
@@ -788,6 +861,9 @@ function state.snapshot()
 
   -- Tags
   payload.tags = snapshot_tags()
+
+  -- Current blind choices and the rewards offered for skipping Small/Big blinds
+  payload.blind_selection = snapshot_blind_selection()
 
   -- Used vouchers
   if G.GAME and G.GAME.used_vouchers then


### PR DESCRIPTION
## Summary

- Fix blind skipping so the native callback receives the selected blind UI object it expects.
- Advertise `skip_blind` only for skippable Small/Big blinds with a live tag and ready UI, and expose each blind's concrete skip reward in state snapshots.
- Correct the Joker reorder tool description: left-to-right order is scoring-relevant, not merely visual.
- Add tactical guidance for Boss restrictions, discard usage, skip-tag evaluation, and Joker ordering.

## Root cause

`G.FUNCS.skip_blind` reads the event/UI object to resolve the tag reward, but the bridge called it without an argument. The state snapshot also exposed neither the current blind choices nor their tag rewards, so an agent could not make an evidence-based skip decision.

Separately, the MCP tool description incorrectly stated that Joker display order did not affect scoring, which could discourage the agent from placing additive Mult before xMult or deliberately positioning Blueprint/Brainstorm.

## Validation

- `cd mcp && pnpm typecheck`
- `cd mcp && pnpm build`
- Manual QA on Windows with Balatro, Lovely, Steamodded, and the MCP bridge during the original reproduction and fix.

The repository currently has no automated test framework, so Lua behavior was validated through the live game bridge.
