### PR TITLE
[Windows] Add full Windows support to the bridge

### DIFF
--- a/mcp/src/bridge/protocol.ts
+++ b/mcp/src/bridge/protocol.ts
@@ -182,3 +182,18 @@ export function isJsonRpcResponse(obj: unknown): obj is JsonRpcResponse {
   if (r.result !== undefined && r.error !== undefined) return false;
   return r.result !== undefined || r.error !== undefined;
 }
+
+/**
+ * Default TCP port used by the Windows (Winsock) bridge backend.
+ *
+ * macOS/Linux use a Unix domain socket at /tmp/balatro-mcp.sock; Windows does
+ * not support AF_UNIX, so the Lua mod listens on a TCP loopback socket instead.
+ * The Lua side (mods/balatro_mcp/src/socket_server.lua) hard-codes the same
+ * default. Keep these in sync.
+ */
+export const DEFAULT_BRIDGE_PORT = 37651;
+
+/**
+ * Loopback host used by the TCP bridge backend on Windows.
+ */
+export const DEFAULT_BRIDGE_HOST = "127.0.0.1";

--- a/mcp/src/bridge/socket-client.ts
+++ b/mcp/src/bridge/socket-client.ts
@@ -1,7 +1,14 @@
 import { createConnection } from "node:net";
 import type { Socket } from "node:net";
 
-import { errorCodeToString, isJsonRpcResponse, parseFrames, serializeFrame } from "./protocol.js";
+import {
+  DEFAULT_BRIDGE_HOST,
+  DEFAULT_BRIDGE_PORT,
+  errorCodeToString,
+  isJsonRpcResponse,
+  parseFrames,
+  serializeFrame,
+} from "./protocol.js";
 import type { JsonRpcRequest, JsonRpcResponse } from "./protocol.js";
 
 const SOCKET_PATH = "/tmp/balatro-mcp.sock";
@@ -9,6 +16,9 @@ const PROTOCOL_VERSION = 1;
 const DEFAULT_RESPONSE_TIMEOUT_MS = 10_000;
 const DEFAULT_STATE_TIMEOUT_MS = 5_000;
 const RECONNECT_DELAY_MS = 500;
+
+// Windows does not support AF_UNIX, so the bridge connects over TCP loopback.
+const IS_WINDOWS = process.platform === "win32";
 
 export interface StateEnvelope {
   protocol_version: number;
@@ -127,11 +137,18 @@ export class BridgeClient {
   private connectedAtMs?: number;
   private lastDisconnectError?: BridgeError;
   private readonly pendingRequests = new Map<number, PendingRequest>();
+  private readonly port: number;
 
-  constructor() {}
+  /**
+   * @param options.port TCP port for the Windows bridge backend. Defaults to
+   *   DEFAULT_BRIDGE_PORT. Ignored on non-Windows platforms (Unix socket used).
+   */
+  constructor(options?: { port?: number }) {
+    this.port = options?.port ?? DEFAULT_BRIDGE_PORT;
+  }
 
   get dir(): string {
-    return SOCKET_PATH;
+    return IS_WINDOWS ? `${DEFAULT_BRIDGE_HOST}:${this.port}` : SOCKET_PATH;
   }
 
   connect(): Promise<void> {
@@ -292,7 +309,9 @@ export class BridgeClient {
     this.clearReconnectTimer();
     this.buffer = "";
 
-    const socket = createConnection({ path: SOCKET_PATH });
+    const socket = IS_WINDOWS
+      ? createConnection({ host: DEFAULT_BRIDGE_HOST, port: this.port })
+      : createConnection({ path: SOCKET_PATH });
     this.socket = socket;
     socket.setEncoding("utf8");
 

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -1,10 +1,29 @@
 import { BridgeClient } from "./bridge/socket-client.js";
+import { DEFAULT_BRIDGE_PORT } from "./bridge/protocol.js";
 import type { Deps } from "./deps.js";
 import { getRulesContent } from "./resources/rules.js";
 import { runServer } from "./server.js";
 
+/**
+ * Read the bridge TCP port from the BALATRO_BRIDGE_PORT environment variable.
+ * Falls back to the protocol default. Invalid values fall back silently.
+ */
+function readBridgePortFromEnv(): number {
+  const raw = process.env.BALATRO_BRIDGE_PORT;
+  if (raw === undefined || raw === "") return DEFAULT_BRIDGE_PORT;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) {
+    process.stderr.write(
+      `[balatro-mcp-server] invalid BALATRO_BRIDGE_PORT "${raw}", using ${DEFAULT_BRIDGE_PORT}\n`,
+    );
+    return DEFAULT_BRIDGE_PORT;
+  }
+  return parsed;
+}
+
 async function main(): Promise<void> {
-  const bridgeClient = new BridgeClient();
+  const port = readBridgePortFromEnv();
+  const bridgeClient = new BridgeClient({ port });
 
   // Kick off the bridge connection in the background. If Balatro is not yet
   // running, connect() rejects and the client keeps retrying in the background

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -5,7 +5,16 @@ import { runServer } from "./server.js";
 
 async function main(): Promise<void> {
   const bridgeClient = new BridgeClient();
-  await bridgeClient.connect();
+
+  // Kick off the bridge connection in the background. If Balatro is not yet
+  // running, connect() rejects and the client keeps retrying in the background
+  // (see BridgeClient.scheduleReconnect). We must NOT exit here — the MCP
+  // server should stay up so a later-started Balatro is picked up automatically.
+  bridgeClient.connect().catch((err: unknown) => {
+    process.stderr.write(
+      `[balatro-mcp-server] bridge not connected yet: ${(err as Error).message}\n`,
+    );
+  });
 
   const deps: Deps = {
     bridgeClient,

--- a/mods/balatro_mcp/src/socket_server.lua
+++ b/mods/balatro_mcp/src/socket_server.lua
@@ -1,60 +1,38 @@
---- socket_server.lua — Non-blocking Unix domain socket server for Balatro MCP.
---- Protocol: newline-delimited JSON messages over /tmp/balatro-mcp.sock.
+--- socket_server.lua — Cross-platform non-blocking socket server for Balatro MCP.
+--- Protocol: newline-delimited JSON messages.
+---
+--- Backends:
+---   - macOS (ffi.os == "OSX"):   Unix domain socket at /tmp/balatro-mcp.sock
+---   - Windows (ffi.os == "Windows"): TCP loopback at 127.0.0.1:PORT (Winsock2)
+---
+--- Exposes the same public interface as before so commands.lua / jsonrpc.lua
+--- are unaffected: init(), update(dt), close(), send_response(json), and the
+--- on_request_callback field.
 
 local ffi = require("ffi")
 local C = ffi.C
 
-ffi.cdef[[
-  struct sockaddr;
-  // Socket creation and management
-  int socket(int domain, int type, int protocol);
-  int bind(int sockfd, const struct sockaddr *addr, unsigned int addrlen);
-  int listen(int sockfd, int backlog);
-  int accept(int sockfd, struct sockaddr *addr, unsigned int *addrlen);
-  int close(int fd);
-
-  // I/O
-  long read(int fd, void *buf, unsigned long count);
-  long write(int fd, const void *buf, unsigned long count);
-
-  // Non-blocking
-  int fcntl(int fd, int cmd, ...);
-
-  // Poll for readiness without blocking the game loop
-  typedef unsigned int nfds_t;
-  typedef struct pollfd {
-    int fd;
-    short events;
-    short revents;
-  } pollfd;
-  int poll(struct pollfd *fds, nfds_t nfds, int timeout);
-
-  // macOS Unix socket address
-  typedef struct {
-    unsigned char sun_len;
-    unsigned char sun_family;
-    char sun_path[104];
-  } sockaddr_un;
-
-  // Constants
-  static const int AF_UNIX = 1;
-  static const int SOCK_STREAM = 1;
-  static const int O_NONBLOCK = 0x0004;  // macOS value
-  static const int F_SETFL = 4;          // macOS value
-  static const int F_GETFL = 3;          // macOS value
-  static const int SOL_SOCKET = 1;       // macOS value
-  static const int SO_REUSEADDR = 2;     // macOS value
-  static const short POLLIN = 0x0001;    // macOS/Linux value
-  static const short POLLHUP = 0x0010;   // macOS/Linux value
-  static const short POLLERR = 0x0008;   // macOS/Linux value
-]]
-
-local SocketServer = {}
+local IS_WINDOWS = ffi.os == "Windows"
 
 local SOCKET_PATH = "/tmp/balatro-mcp.sock"
+local HOST = "127.0.0.1"
+
+-- Windows bridge port. Overridable via BALATRO_BRIDGE_PORT to match the MCP
+-- server; falls back to the protocol default (37651).
+local PORT = 37651
+if IS_WINDOWS then
+  local env_port = os.getenv and os.getenv("BALATRO_BRIDGE_PORT")
+  local parsed = env_port and tonumber(env_port)
+  if parsed and parsed >= 1 and parsed <= 65535 then
+    PORT = math.floor(parsed)
+  end
+end
 local READ_BUFFER_SIZE = 4096
-local EAGAIN = ffi.os == "OSX" and 35 or 11
-local EWOULDBLOCK = EAGAIN
+local MAX_LINE_BUFFER_SIZE = 65536
+
+local EAGAIN
+local EWOULDBLOCK
+local WSAEWOULDBLOCK = 10035
 
 local server_fd = -1
 local client_fd = -1
@@ -62,9 +40,14 @@ local initialized = false
 local has_client = false
 local line_buffer = ""
 local read_buffer = ffi.new("char[?]", READ_BUFFER_SIZE)
-local poll_fds = ffi.new("pollfd[1]")
+
+local SocketServer = {}
 
 SocketServer.on_request_callback = nil
+
+-- Winsock handle (Windows). Loaded lazily inside the `if IS_WINDOWS` block to
+-- keep it available to the error helpers defined below. Nil on POSIX.
+local W
 
 local function log(message)
   if sendDebugMessage then
@@ -72,293 +55,664 @@ local function log(message)
   end
 end
 
-local function errno_is_would_block(errno)
-  return errno == EAGAIN or errno == EWOULDBLOCK
-end
-
 local function errno_message(prefix)
-  return prefix .. " (errno " .. tostring(ffi.errno()) .. ")"
+  return prefix .. " (errno " .. tostring(last_wsa_error()) .. ")"
 end
 
-local function set_nonblocking(fd)
-  local flags = C.fcntl(fd, C.F_GETFL, 0)
-  if flags < 0 then
-    return false, errno_message("fcntl(F_GETFL) failed")
+-- Winsock uses WSAGetLastError() instead of errno; values are positive (e.g. 10035).
+-- LuaJIT ffi.errno()/errno number is only meaningful on POSIX.
+local function last_wsa_error()
+  if IS_WINDOWS and W then
+    return W.WSAGetLastError()
   end
-
-  flags = tonumber(flags) or 0
-  local nonblock = tonumber(C.O_NONBLOCK)
-  local has_nonblock = math.floor(flags / nonblock) % 2 == 1
-  local new_flags = has_nonblock and flags or (flags + nonblock)
-
-  if C.fcntl(fd, C.F_SETFL, new_flags) < 0 then
-    return false, errno_message("fcntl(F_SETFL) failed")
-  end
-
-  return true
+  return ffi.errno()
 end
 
-local function poll_readable(fd)
-  poll_fds[0].fd = fd
-  poll_fds[0].events = C.POLLIN
-  poll_fds[0].revents = 0
+local function errno_is_would_block(errno)
+  return errno == EAGAIN or errno == EWOULDBLOCK or errno == WSAEWOULDBLOCK
+end
 
-  local ready = C.poll(poll_fds, 1, 0)
-  if ready < 0 then
-    local errno = ffi.errno()
-    if not errno_is_would_block(errno) then
-      return false, true, errno
+---------------------------------------------------------------------------
+-- Winsock2 backend (Windows)
+---------------------------------------------------------------------------
+
+if IS_WINDOWS then
+  W = ffi.load("ws2_32")
+
+  ffi.cdef[[
+    typedef unsigned long u_long;
+    typedef struct {
+      unsigned short sin_family;
+      unsigned short sin_port;
+      unsigned long sin_addr;
+      char sin_zero[8];
+    } sockaddr_in;
+
+    int WSAStartup(unsigned short wVersionRequested, void *lpWSAData);
+    void WSACleanup(void);
+    int WSAGetLastError(void);
+    intptr_t socket(int af, int type, int protocol);
+    int bind(intptr_t s, const void *name, int namelen);
+    int listen(intptr_t s, int backlog);
+    intptr_t accept(intptr_t s, void *addr, int *addrlen);
+    int closesocket(intptr_t s);
+    int ioctlsocket(intptr_t s, long cmd, u_long *argp);
+    long recv(intptr_t s, void *buf, unsigned long len, int flags);
+    long send(intptr_t s, const void *buf, unsigned long len, int flags);
+    int select(int nfds, void *readfds, void *writefds, void *exceptfds, void *timeout);
+    unsigned long inet_addr(const char *cp);
+    unsigned short htons(unsigned short hostshort);
+    int setsockopt(intptr_t s, int level, int optname, const void *optval, int optlen);
+    typedef struct {
+      unsigned long fd_count;
+      uintptr_t fd_array[64];
+    } fd_set_arr;
+    typedef struct {
+      long tv_sec;
+      long tv_usec;
+    } timeval;
+  ]]
+
+  -- WSADATA size on Windows (approx 408 bytes); zero-init is enough for WSAStartup
+  local wsadata = ffi.new("char[?]", 512)
+
+  -- Constants
+  local AF_INET = 2
+  local SOCK_STREAM = 1
+  local IPPROTO_TCP = 6
+  local SOL_SOCKET = 0xffff
+  local SO_REUSEADDR = 0x0004
+  -- FIONBIO = 0x8004667e, 但 LuaJIT 的 long 参数是 32 位有符号，必须用有符号表示
+  local FIONBIO = -2147195266
+  local MAKEWORD = 0x0202  -- request Winsock 2.2
+  local SOCKET_ERROR = -1
+
+  -- Non-blocking flag
+  local function set_nonblocking(fd)
+    local one = ffi.new("u_long[1]", 1)
+    if W.ioctlsocket(fd, FIONBIO, one) ~= 0 then
+      return false, errno_message("ioctlsocket(FIONBIO) failed")
     end
-    return false, false, errno
+    return true
   end
 
-  if ready == 0 then
-    return false, false, nil
+  -- select() readiness check against a single fd (read ready)
+  -- Returns (readable, error_flag, errno)
+  local fdset = ffi.new("fd_set_arr")
+  local tv = ffi.new("timeval")
+  tv.tv_sec = 0
+  tv.tv_usec = 0
+
+  local function fd_set_zero()
+    ffi.fill(fdset, ffi.sizeof(fdset), 0)
   end
 
-  local revents = tonumber(poll_fds[0].revents) or 0
-  if math.floor(revents / tonumber(C.POLLERR)) % 2 == 1 then
-    return false, true, nil
-  end
-  if math.floor(revents / tonumber(C.POLLHUP)) % 2 == 1 then
-    return false, true, nil
+  local function fd_set_add(fd)
+    fdset.fd_array[fdset.fd_count] = fd
+    fdset.fd_count = fdset.fd_count + 1
   end
 
-  return math.floor(revents / tonumber(C.POLLIN)) % 2 == 1, false, nil
-end
-
-local function close_client(reason)
-  if has_client and client_fd >= 0 then
-    C.close(client_fd)
-    if reason then
-      log("Socket client closed: " .. tostring(reason))
-    else
-      log("Socket client disconnected")
+  local function fd_set_isset(fd)
+    for i = 0, tonumber(fdset.fd_count) - 1 do
+      if tonumber(fdset.fd_array[i]) == fd then
+        return true
+      end
     end
+    return false
   end
 
-  client_fd = -1
-  has_client = false
-  line_buffer = ""
-end
-
-local function dispatch_line(line)
-  if line == "" then return end
-  if line:sub(-1) == "\r" then
-    line = line:sub(1, -2)
-  end
-  if line == "" then return end
-
-  if not JSON or not JSON.decode then
-    log("Cannot decode socket request: JSON.decode unavailable")
-    return
-  end
-
-  local decode_ok, decoded = pcall(JSON.decode, line)
-  if not decode_ok or decoded == nil then
-    log("Invalid JSON socket request: " .. tostring(decoded))
-    return
-  end
-
-  local callback = SocketServer.on_request_callback
-  if callback then
-    local callback_ok, callback_err = pcall(callback, decoded)
-    if not callback_ok then
-      log("Socket request callback failed: " .. tostring(callback_err))
+  local function poll_readable(fd)
+    fd_set_zero()
+    local n = 0
+    -- select with a single fd: use fd_set wrapper
+    fd_set_add(fd)
+    n = W.select(0, fdset, nil, nil, tv)
+    if n == SOCKET_ERROR then
+      return false, true, last_wsa_error()
     end
-  else
-    log("Socket request received before callback was registered")
-  end
-end
-
-local function process_line_buffer()
-  while true do
-    local newline_at = line_buffer:find("\n", 1, true)
-    if not newline_at then return end
-
-    local line = line_buffer:sub(1, newline_at - 1)
-    line_buffer = line_buffer:sub(newline_at + 1)
-    dispatch_line(line)
-  end
-end
-
-local function accept_pending_client()
-  if server_fd < 0 then return end
-
-  local readable, failed, errno = poll_readable(server_fd)
-  if failed then
-    log("Socket accept poll failed" .. (errno and (" (errno " .. tostring(errno) .. ")") or ""))
-    return
-  end
-  if not readable then return end
-
-  local accepted_fd = C.accept(server_fd, nil, nil)
-  if accepted_fd < 0 then
-    local errno = ffi.errno()
-    if not errno_is_would_block(errno) then
-      log("Socket accept failed (errno " .. tostring(errno) .. ")")
+    if n == 0 then
+      return false, false, nil
     end
-    return
+    return fd_set_isset(fd), false, nil
   end
 
-  if has_client then
-    C.close(accepted_fd)
-    log("Rejected extra socket client; one client is already connected")
-    return
+  local function create_server()
+    if W.WSAStartup(MAKEWORD, wsadata) ~= 0 then
+      return -1, "WSAStartup failed"
+    end
+
+    local fd = W.socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)
+    if fd == SOCKET_ERROR then
+      W.WSACleanup()
+      return -1, "socket() failed"
+    end
+
+    -- SO_REUSEADDR to avoid TIME_WAIT issues on restart
+    local opt = ffi.new("int[1]", 1)
+    W.setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, opt, ffi.sizeof("int"))
+
+    local ok, err = set_nonblocking(fd)
+    if not ok then
+      W.closesocket(fd)
+      W.WSACleanup()
+      return -1, err
+    end
+
+    local addr = ffi.new("sockaddr_in")
+    addr.sin_family = AF_INET
+    addr.sin_port = W.htons(PORT)
+    addr.sin_addr = W.inet_addr(HOST)
+
+    if W.bind(fd, addr, ffi.sizeof(addr)) ~= 0 then
+      W.closesocket(fd)
+      W.WSACleanup()
+      return -1, "bind() failed on " .. HOST .. ":" .. PORT
+    end
+
+    if W.listen(fd, 1) ~= 0 then
+      W.closesocket(fd)
+      W.WSACleanup()
+      return -1, "listen() failed"
+    end
+
+    return fd, nil
   end
 
-  local ok, err = set_nonblocking(accepted_fd)
-  if not ok then
-    C.close(accepted_fd)
-    log("Accepted socket client but failed to make it non-blocking: " .. tostring(err))
-    return
+  SocketServer.get_endpoint = function()
+    return HOST .. ":" .. PORT
   end
 
-  client_fd = accepted_fd
-  has_client = true
-  line_buffer = ""
-  log("Socket client connected")
-end
-
-local MAX_LINE_BUFFER_SIZE = 65536
-
-local function read_from_client()
-  if not has_client or client_fd < 0 then return end
-
-  local readable, failed, errno = poll_readable(client_fd)
-  if failed then
-    log("Socket client poll failed" .. (errno and (" (errno " .. tostring(errno) .. ")") or ""))
-    close_client("poll failed")
-    return
-  end
-  if not readable then return end
-
-  local bytes_read = C.read(client_fd, read_buffer, READ_BUFFER_SIZE)
-  if bytes_read > 0 then
-    line_buffer = line_buffer .. ffi.string(read_buffer, bytes_read)
-    if #line_buffer > MAX_LINE_BUFFER_SIZE then
-      log("Client exceeded max frame size, disconnecting")
-      close_client("buffer overflow")
+  local function accept_pending_client()
+    if server_fd < 0 then return end
+    local readable, failed = poll_readable(server_fd)
+    if failed then
+      log("Socket accept poll failed")
       return
     end
-    process_line_buffer()
-    return
+    if not readable then return end
+
+    local accepted_fd = W.accept(server_fd, nil, nil)
+    if accepted_fd == SOCKET_ERROR then
+      local err = last_wsa_error()
+      if not errno_is_would_block(err) then
+        log("Socket accept failed (errno " .. tostring(err) .. ")")
+      end
+      return
+    end
+
+    if has_client then
+      W.closesocket(accepted_fd)
+      log("Rejected extra socket client; one client is already connected")
+      return
+    end
+
+    local ok, err = set_nonblocking(accepted_fd)
+    if not ok then
+      W.closesocket(accepted_fd)
+      log("Accepted socket client but failed to make it non-blocking: " .. tostring(err))
+      return
+    end
+
+    client_fd = accepted_fd
+    has_client = true
+    line_buffer = ""
+    log("Socket client connected (" .. SocketServer.get_endpoint() .. ")")
   end
 
-  if bytes_read == 0 then
-    close_client("peer disconnected")
-    return
+  local function dispatch_line(line)
+    if line == "" then return end
+    if line:sub(-1) == "\r" then
+      line = line:sub(1, -2)
+    end
+    if line == "" then return end
+
+    if not JSON or not JSON.decode then
+      log("Cannot decode socket request: JSON.decode unavailable")
+      return
+    end
+
+    local decode_ok, decoded = pcall(JSON.decode, line)
+    if not decode_ok or decoded == nil then
+      log("Invalid JSON socket request: " .. tostring(decoded))
+      return
+    end
+
+    local callback = SocketServer.on_request_callback
+    if callback then
+      local callback_ok, callback_err = pcall(callback, decoded)
+      if not callback_ok then
+        log("Socket request callback failed: " .. tostring(callback_err))
+      end
+    else
+      log("Socket request received before callback was registered")
+    end
   end
 
-  local errno = ffi.errno()
-  if not errno_is_would_block(errno) then
-    log("Socket read failed (errno " .. tostring(errno) .. ")")
-    close_client("read failed")
-  end
-end
-
-function SocketServer.init()
-  if initialized then return true end
-
-  os.remove(SOCKET_PATH)
-
-  local fd = C.socket(C.AF_UNIX, C.SOCK_STREAM, 0)
-  if fd < 0 then
-    log(errno_message("Socket creation failed"))
-    return false
+  local function process_line_buffer()
+    while true do
+      local newline_at = line_buffer:find("\n", 1, true)
+      if not newline_at then return end
+      local line = line_buffer:sub(1, newline_at - 1)
+      line_buffer = line_buffer:sub(newline_at + 1)
+      dispatch_line(line)
+    end
   end
 
-  local ok, err = set_nonblocking(fd)
-  if not ok then
-    C.close(fd)
-    log("Socket server non-blocking setup failed: " .. tostring(err))
-    return false
+  local function close_client(reason)
+    if has_client and client_fd >= 0 then
+      W.closesocket(client_fd)
+      if reason then
+        log("Socket client closed: " .. tostring(reason))
+      else
+        log("Socket client disconnected")
+      end
+    end
+    client_fd = -1
+    has_client = false
+    line_buffer = ""
   end
 
-  local addr = ffi.new("sockaddr_un")
-  addr.sun_len = ffi.sizeof(addr)
-  addr.sun_family = C.AF_UNIX
-  ffi.copy(addr.sun_path, SOCKET_PATH, #SOCKET_PATH)
+  local function read_from_client()
+    if not has_client or client_fd < 0 then return end
 
-  local bind_ok = C.bind(fd, ffi.cast("const struct sockaddr *", addr), ffi.sizeof(addr))
-  if bind_ok < 0 then
-    log(errno_message("Socket bind failed"))
-    C.close(fd)
-    os.remove(SOCKET_PATH)
-    return false
+    local readable, failed = poll_readable(client_fd)
+    if failed then
+      log("Socket client poll failed")
+      close_client("poll failed")
+      return
+    end
+    if not readable then return end
+
+    local bytes_read = W.recv(client_fd, read_buffer, READ_BUFFER_SIZE, 0)
+    if bytes_read > 0 then
+      line_buffer = line_buffer .. ffi.string(read_buffer, bytes_read)
+      if #line_buffer > MAX_LINE_BUFFER_SIZE then
+        log("Client exceeded max frame size, disconnecting")
+        close_client("buffer overflow")
+        return
+      end
+      process_line_buffer()
+      return
+    end
+
+    if bytes_read == 0 then
+      close_client("peer disconnected")
+      return
+    end
+
+    local err = last_wsa_error()
+    if not errno_is_would_block(err) then
+      log("Socket recv failed (errno " .. tostring(err) .. ")")
+      close_client("recv failed")
+    end
   end
 
-  if C.listen(fd, 1) < 0 then
-    log(errno_message("Socket listen failed"))
-    C.close(fd)
-    os.remove(SOCKET_PATH)
-    return false
-  end
+  SocketServer.init = function()
+    if initialized then return true end
 
-  server_fd = fd
-  initialized = true
-  log("Socket server listening on " .. SOCKET_PATH)
-  return true
-end
-
-function SocketServer.update(dt)
-  if not initialized then return end
-
-  accept_pending_client()
-  read_from_client()
-end
-
-function SocketServer.send_response(response_json)
-  if not has_client or client_fd < 0 then
-    log("Cannot send socket response: no client connected")
-    return false
-  end
-
-  local payload = response_json
-  if type(payload) ~= "string" then
-    if not JSON or not JSON.encode then
-      log("Cannot encode socket response: JSON.encode unavailable")
-      close_client("response encode failed")
+    local fd, err = create_server()
+    if fd < 0 then
+      log("Socket server init failed: " .. tostring(err))
       return false
     end
 
-    local encode_ok, encoded = pcall(JSON.encode, payload)
-    if not encode_ok or type(encoded) ~= "string" then
-      log("Failed to encode socket response: " .. tostring(encoded))
-      close_client("response encode failed")
+    server_fd = fd
+    initialized = true
+    log("Socket server listening on " .. SocketServer.get_endpoint())
+    return true
+  end
+
+  SocketServer.update = function(dt)
+    if not initialized then return end
+    accept_pending_client()
+    read_from_client()
+  end
+
+  SocketServer.send_response = function(response_json)
+    if not has_client or client_fd < 0 then
+      log("Cannot send socket response: no client connected")
       return false
     end
-    payload = encoded
+
+    local payload = response_json
+    if type(payload) ~= "string" then
+      if not JSON or not JSON.encode then
+        log("Cannot encode socket response: JSON.encode unavailable")
+        close_client("response encode failed")
+        return false
+      end
+      local encode_ok, encoded = pcall(JSON.encode, payload)
+      if not encode_ok or type(encoded) ~= "string" then
+        log("Failed to encode socket response: " .. tostring(encoded))
+        close_client("response encode failed")
+        return false
+      end
+      payload = encoded
+    end
+
+    payload = payload .. "\n"
+    local bytes_written = W.send(client_fd, payload, #payload, 0)
+    if bytes_written == SOCKET_ERROR then
+      local err = last_wsa_error()
+      if not errno_is_would_block(err) then
+        log("Socket response send failed (errno " .. tostring(err) .. ")")
+        close_client("send failed")
+      end
+      return false
+    end
+
+    if bytes_written < #payload then
+      log("Socket response send was partial; closing client")
+      close_client("partial send")
+      return false
+    end
+
+    return true
   end
 
-  payload = payload .. "\n"
-  local bytes_written = C.write(client_fd, payload, #payload)
-  if bytes_written < 0 then
-    log("Socket response write failed (errno " .. tostring(ffi.errno()) .. ")")
-    close_client("write failed")
-    return false
+  SocketServer.close = function()
+    close_client(nil)
+    if server_fd >= 0 then
+      W.closesocket(server_fd)
+      server_fd = -1
+    end
+    W.WSACleanup()
+    initialized = false
+    log("Socket server closed")
   end
-
-  if bytes_written < #payload then
-    log("Socket response write was partial; closing client")
-    close_client("partial write")
-    return false
-  end
-
-  return true
 end
 
-function SocketServer.close()
-  close_client(nil)
+---------------------------------------------------------------------------
+-- POSIX backend (macOS / Linux) — Unix domain socket
+---------------------------------------------------------------------------
 
-  if server_fd >= 0 then
-    C.close(server_fd)
-    server_fd = -1
+if not IS_WINDOWS then
+  C = ffi.C
+
+  ffi.cdef[[
+    struct sockaddr;
+    int socket(int domain, int type, int protocol);
+    int bind(int sockfd, const struct sockaddr *addr, unsigned int addrlen);
+    int listen(int sockfd, int backlog);
+    int accept(int sockfd, struct sockaddr *addr, unsigned int *addrlen);
+    int close(int fd);
+    long read(int fd, void *buf, unsigned long count);
+    long write(int fd, const void *buf, unsigned long count);
+    int fcntl(int fd, int cmd, ...);
+    typedef unsigned int nfds_t;
+    typedef struct pollfd {
+      int fd;
+      short events;
+      short revents;
+    } pollfd;
+    int poll(struct pollfd *fds, nfds_t nfds, int timeout);
+
+    typedef struct {
+      unsigned char sun_len;
+      unsigned char sun_family;
+      char sun_path[104];
+    } sockaddr_un;
+
+    static const int AF_UNIX = 1;
+    static const int SOCK_STREAM = 1;
+    static const int O_NONBLOCK = 0x0004;
+    static const int F_SETFL = 4;
+    static const int F_GETFL = 3;
+    static const int SOL_SOCKET = 1;
+    static const int SO_REUSEADDR = 2;
+    static const short POLLIN = 0x0001;
+    static const short POLLHUP = 0x0010;
+    static const short POLLERR = 0x0008;
+  ]]
+
+  EAGAIN = ffi.os == "OSX" and 35 or 11
+  EWOULDBLOCK = EAGAIN
+
+  local poll_fds = ffi.new("pollfd[1]")
+
+  local function errno_is_would_block(errno)
+    return errno == EAGAIN or errno == EWOULDBLOCK
   end
 
-  os.remove(SOCKET_PATH)
-  initialized = false
-  log("Socket server closed")
+  local function set_nonblocking(fd)
+    local flags = C.fcntl(fd, C.F_GETFL, 0)
+    if flags < 0 then
+      return false, errno_message("fcntl(F_GETFL) failed")
+    end
+    flags = tonumber(flags) or 0
+    local nonblock = tonumber(C.O_NONBLOCK)
+    local has_nonblock = math.floor(flags / nonblock) % 2 == 1
+    local new_flags = has_nonblock and flags or (flags + nonblock)
+    if C.fcntl(fd, C.F_SETFL, new_flags) < 0 then
+      return false, errno_message("fcntl(F_SETFL) failed")
+    end
+    return true
+  end
+
+  local function poll_readable(fd)
+    poll_fds[0].fd = fd
+    poll_fds[0].events = C.POLLIN
+    poll_fds[0].revents = 0
+    local ready = C.poll(poll_fds, 1, 0)
+    if ready < 0 then
+      local errno = ffi.errno()
+      return false, true, errno
+    end
+    if ready == 0 then
+      return false, false, nil
+    end
+    local revents = tonumber(poll_fds[0].revents) or 0
+    if math.floor(revents / tonumber(C.POLLERR)) % 2 == 1 then
+      return false, true, nil
+    end
+    if math.floor(revents / tonumber(C.POLLHUP)) % 2 == 1 then
+      return false, true, nil
+    end
+    return math.floor(revents / tonumber(C.POLLIN)) % 2 == 1, false, nil
+  end
+
+  local function close_client(reason)
+    if has_client and client_fd >= 0 then
+      C.close(client_fd)
+      if reason then
+        log("Socket client closed: " .. tostring(reason))
+      else
+        log("Socket client disconnected")
+      end
+    end
+    client_fd = -1
+    has_client = false
+    line_buffer = ""
+  end
+
+  local function dispatch_line(line)
+    if line == "" then return end
+    if line:sub(-1) == "\r" then
+      line = line:sub(1, -2)
+    end
+    if line == "" then return end
+    if not JSON or not JSON.decode then
+      log("Cannot decode socket request: JSON.decode unavailable")
+      return
+    end
+    local decode_ok, decoded = pcall(JSON.decode, line)
+    if not decode_ok or decoded == nil then
+      log("Invalid JSON socket request: " .. tostring(decoded))
+      return
+    end
+    local callback = SocketServer.on_request_callback
+    if callback then
+      local callback_ok, callback_err = pcall(callback, decoded)
+      if not callback_ok then
+        log("Socket request callback failed: " .. tostring(callback_err))
+      end
+    else
+      log("Socket request received before callback was registered")
+    end
+  end
+
+  local function process_line_buffer()
+    while true do
+      local newline_at = line_buffer:find("\n", 1, true)
+      if not newline_at then return end
+      local line = line_buffer:sub(1, newline_at - 1)
+      line_buffer = line_buffer:sub(newline_at + 1)
+      dispatch_line(line)
+    end
+  end
+
+  local function accept_pending_client()
+    if server_fd < 0 then return end
+    local readable, failed, errno = poll_readable(server_fd)
+    if failed then
+      log("Socket accept poll failed" .. (errno and (" (errno " .. tostring(errno) .. ")") or ""))
+      return
+    end
+    if not readable then return end
+    local accepted_fd = C.accept(server_fd, nil, nil)
+    if accepted_fd < 0 then
+      local errno = ffi.errno()
+      if not errno_is_would_block(errno) then
+        log("Socket accept failed (errno " .. tostring(errno) .. ")")
+      end
+      return
+    end
+    if has_client then
+      C.close(accepted_fd)
+      log("Rejected extra socket client; one client is already connected")
+      return
+    end
+    local ok, err = set_nonblocking(accepted_fd)
+    if not ok then
+      C.close(accepted_fd)
+      log("Accepted socket client but failed to make it non-blocking: " .. tostring(err))
+      return
+    end
+    client_fd = accepted_fd
+    has_client = true
+    line_buffer = ""
+    log("Socket client connected")
+  end
+
+  local function read_from_client()
+    if not has_client or client_fd < 0 then return end
+    local readable, failed, errno = poll_readable(client_fd)
+    if failed then
+      log("Socket client poll failed" .. (errno and (" (errno " .. tostring(errno) .. ")") or ""))
+      close_client("poll failed")
+      return
+    end
+    if not readable then return end
+    local bytes_read = C.read(client_fd, read_buffer, READ_BUFFER_SIZE)
+    if bytes_read > 0 then
+      line_buffer = line_buffer .. ffi.string(read_buffer, bytes_read)
+      if #line_buffer > MAX_LINE_BUFFER_SIZE then
+        log("Client exceeded max frame size, disconnecting")
+        close_client("buffer overflow")
+        return
+      end
+      process_line_buffer()
+      return
+    end
+    if bytes_read == 0 then
+      close_client("peer disconnected")
+      return
+    end
+    local errno = ffi.errno()
+    if not errno_is_would_block(errno) then
+      log("Socket read failed (errno " .. tostring(errno) .. ")")
+      close_client("read failed")
+    end
+  end
+
+  SocketServer.init = function()
+    if initialized then return true end
+    os.remove(SOCKET_PATH)
+    local fd = C.socket(C.AF_UNIX, C.SOCK_STREAM, 0)
+    if fd < 0 then
+      log(errno_message("Socket creation failed"))
+      return false
+    end
+    local ok, err = set_nonblocking(fd)
+    if not ok then
+      C.close(fd)
+      log("Socket server non-blocking setup failed: " .. tostring(err))
+      return false
+    end
+    local addr = ffi.new("sockaddr_un")
+    addr.sun_len = ffi.sizeof(addr)
+    addr.sun_family = C.AF_UNIX
+    ffi.copy(addr.sun_path, SOCKET_PATH, #SOCKET_PATH)
+    local bind_ok = C.bind(fd, ffi.cast("const struct sockaddr *", addr), ffi.sizeof(addr))
+    if bind_ok < 0 then
+      log(errno_message("Socket bind failed"))
+      C.close(fd)
+      os.remove(SOCKET_PATH)
+      return false
+    end
+    if C.listen(fd, 1) < 0 then
+      log(errno_message("Socket listen failed"))
+      C.close(fd)
+      os.remove(SOCKET_PATH)
+      return false
+    end
+    server_fd = fd
+    initialized = true
+    log("Socket server listening on " .. SOCKET_PATH)
+    return true
+  end
+
+  SocketServer.update = function(dt)
+    if not initialized then return end
+    accept_pending_client()
+    read_from_client()
+  end
+
+  SocketServer.send_response = function(response_json)
+    if not has_client or client_fd < 0 then
+      log("Cannot send socket response: no client connected")
+      return false
+    end
+    local payload = response_json
+    if type(payload) ~= "string" then
+      if not JSON or not JSON.encode then
+        log("Cannot encode socket response: JSON.encode unavailable")
+        close_client("response encode failed")
+        return false
+      end
+      local encode_ok, encoded = pcall(JSON.encode, payload)
+      if not encode_ok or type(encoded) ~= "string" then
+        log("Failed to encode socket response: " .. tostring(encoded))
+        close_client("response encode failed")
+        return false
+      end
+      payload = encoded
+    end
+    payload = payload .. "\n"
+    local bytes_written = C.write(client_fd, payload, #payload)
+    if bytes_written < 0 then
+      log("Socket response write failed (errno " .. tostring(ffi.errno()) .. ")")
+      close_client("write failed")
+      return false
+    end
+    if bytes_written < #payload then
+      log("Socket response write was partial; closing client")
+      close_client("partial write")
+      return false
+    end
+    return true
+  end
+
+  SocketServer.close = function()
+    close_client(nil)
+    if server_fd >= 0 then
+      C.close(server_fd)
+      server_fd = -1
+    end
+    os.remove(SOCKET_PATH)
+    initialized = false
+    log("Socket server closed")
+  end
 end
 
 return SocketServer

--- a/scripts/setup-windows.ps1
+++ b/scripts/setup-windows.ps1
@@ -1,0 +1,148 @@
+#Requires -Version 5.1
+<#
+  setup-windows.ps1 — Balatro MCP: Windows install/build/doctor helper.
+
+  Replaces the macOS Makefile targets on Windows:
+    .\scripts\setup-windows.ps1 doctor        Check paths & tools
+    .\scripts\setup-windows.ps1 install-mods  Copy repo mods -> %APPDATA%\Balatro\Mods
+    .\scripts\setup-windows.ps1 build         Build the MCP server (pnpm)
+    .\scripts\setup-windows.ps1 all          install-mods + build
+
+  Overrides (optional):
+    -ModsDir    Balatro mods directory (default: %APPDATA%\Balatro\Mods)
+    -BalatroDir Balatro game directory (default: auto-detect via Steam)
+    -Port       Bridge TCP port (default: 37651, matches the Lua default). This
+              is informational for doctor; to actually change the port, set the
+              BALATRO_BRIDGE_PORT env var before launching Balatro and the MCP
+              server (both the mod and the server read it).
+#>
+param(
+  [ValidateSet('doctor','install-mods','build','all')]
+  [string]$Command = 'doctor',
+
+  [string]$ModsDir,
+  [string]$BalatroDir,
+  [string]$Port = '37651'
+)
+
+$ErrorActionPreference = 'Stop'
+$Root = Split-Path -Parent $PSScriptRoot
+$RepoMods = Join-Path $Root 'mods'
+$MCPDir = Join-Path $Root 'mcp'
+
+if (-not $ModsDir) {
+  $ModsDir = Join-Path $env:APPDATA 'Balatro\Mods'
+}
+
+function Get-BalatroDir {
+  # 1) Common hard-coded Steam locations
+  $candidates = @(
+    'C:\Program Files (x86)\Steam\steamapps\common\Balatro',
+    'C:\Program Files\Steam\steamapps\common\Balatro',
+    (Join-Path $env:ProgramFiles 'Steam\steamapps\common\Balatro'),
+    (Join-Path ${env:ProgramFiles(x86)} 'Steam\steamapps\common\Balatro')
+  )
+
+  # 2) Additional library folders from Steam's libraryfolders.vdf
+  $vdfPaths = @(
+    'C:\Program Files (x86)\Steam\steamapps\libraryfolders.vdf',
+    'C:\Program Files\Steam\steamapps\libraryfolders.vdf',
+    (Join-Path $env:ProgramFiles 'Steam\steamapps\libraryfolders.vdf'),
+    (Join-Path ${env:ProgramFiles(x86)} 'Steam\steamapps\libraryfolders.vdf'),
+    'D:\Steam\steamapps\libraryfolders.vdf',
+    'E:\Steam\steamapps\libraryfolders.vdf',
+    'F:\Steam\steamapps\libraryfolders.vdf'
+  )
+  foreach ($vdf in $vdfPaths) {
+    if (Test-Path $vdf) {
+      # Extract "path" entries from libraryfolders.vdf
+      $paths = Select-String -Path $vdf -Pattern '"path"\s+"([^"]+)"' |
+        ForEach-Object { $_.Matches[0].Groups[1].Value }
+      foreach ($p in $paths) {
+        $candidates += (Join-Path $p 'steamapps\common\Balatro')
+      }
+    }
+  }
+
+  foreach ($c in ($candidates | Select-Object -Unique)) {
+    if ($c -and (Test-Path (Join-Path $c 'Balatro.exe'))) { return $c }
+  }
+  return $null
+}
+
+function Write-Step($msg) { Write-Host "==> $msg" -ForegroundColor Cyan }
+function Write-Ok($msg)   { Write-Host "  OK: $msg" -ForegroundColor Green }
+function Write-Warn($msg) { Write-Host "  WARN: $msg" -ForegroundColor Yellow }
+function Write-Err($msg)  { Write-Host "  ERROR: $msg" -ForegroundColor Red }
+
+function Test-Tool([string]$name) {
+  return $null -ne (Get-Command $name -ErrorAction SilentlyContinue)
+}
+
+function Invoke-Doctor {
+  Write-Step "Balatro MCP - Windows environment check"
+  Write-Host "  Repo: $Root"
+
+  if (-not $BalatroDir) { $BalatroDir = Get-BalatroDir }
+  if ($BalatroDir -and (Test-Path $BalatroDir)) {
+    Write-Ok "Balatro game dir: $BalatroDir"
+  } else {
+    Write-Warn "Balatro game dir not detected. Pass -BalatroDir on Steam download."
+  }
+
+  if (Test-Path $ModsDir) {
+    Write-Ok "Mods dir exists: $ModsDir"
+  } else {
+    Write-Warn "Mods dir missing (game not run yet): $ModsDir"
+  }
+
+  if (Test-Tool 'node') { Write-Ok "node $(node --version)" } else { Write-Err "node not found" }
+  if (Test-Tool 'pnpm') { Write-Ok "pnpm $(pnpm --version)" } else { Write-Err "pnpm not found" }
+  if (Test-Tool 'luac') { Write-Ok "luac available" } else { Write-Warn "luac not found (Lua syntax check skipped)" }
+
+  Write-Host "  Bridge port: $Port"
+}
+
+function Invoke-InstallMods {
+  Write-Step "Installing repo mods -> $ModsDir"
+  if (-not (Test-Path $RepoMods)) { Write-Err "repo mods dir missing: $RepoMods"; exit 1 }
+  New-Item -ItemType Directory -Force -Path $ModsDir | Out-Null
+
+  $installed = 0
+  Get-ChildItem -Path $RepoMods -Directory | ForEach-Object {
+    $name = $_.Name
+    if ($name -eq 'smods') { Write-Warn "Skipping reserved mod name: smods"; return }
+    $dst = Join-Path $ModsDir $name
+    Write-Host "  syncing $name -> $dst"
+    # Remove stale destination entirely, then copy fresh (preserves subdirs like src/)
+    if (Test-Path $dst) { Remove-Item $dst -Recurse -Force }
+    New-Item -ItemType Directory -Force -Path $dst | Out-Null
+    Copy-Item -Path (Join-Path $_.FullName '*') -Destination $dst -Recurse -Force
+    $installed++
+  }
+
+  if ($installed -eq 0) { Write-Warn "No mods installed from $RepoMods" }
+  else { Write-Ok "Installed $installed mod(s). Restart Balatro to load." }
+}
+
+function Invoke-Build {
+  Write-Step "Building MCP server"
+  if (-not (Test-Path (Join-Path $MCPDir 'package.json'))) { Write-Err "mcp/package.json missing"; exit 1 }
+  Push-Location $MCPDir
+  try {
+    if (-not (Test-Path (Join-Path $MCPDir 'node_modules'))) { Write-Host "  pnpm install..."; pnpm install }
+    Write-Host "  pnpm build..."
+    pnpm build
+    if ($LASTEXITCODE -ne 0) { throw "pnpm build failed (exit $LASTEXITCODE)" }
+  } finally { Pop-Location }
+  Write-Ok "MCP server built at $MCPDir/dist/index.js"
+}
+
+switch ($Command) {
+  'doctor'       { Invoke-Doctor }
+  'install-mods' { Invoke-InstallMods }
+  'build'        { Invoke-Build }
+  'all'          { Invoke-InstallMods; Invoke-Build }
+}
+
+Write-Host "`nDone."


### PR DESCRIPTION
## Summary

Adds full Windows support to the Balatro MCP bridge. The repo previously
only supported macOS (Unix domain socket via LuaJIT FFI). This PR makes the
bridge cross-platform without changing the existing macOS behavior.

- **macOS/Linux**: unchanged — POSIX Unix domain socket at `/tmp/balatro-mcp.sock`
- **Windows**: new TCP loopback backend (`127.0.0.1:37651`) using LuaJIT FFI
  against Winsock2 (`ws2_32`), driven by the same non-blocking `select`-based
  loop; the MCP server connects over TCP loopback, keeping the JSON-RPC /
  NDJSON framing protocol identical.

## Changes

- `mods/balatro_mcp/src/socket_server.lua`
  - Split into platform backends selected by `ffi.os`.
  - New Windows backend: `ffi.load("ws2_32")`, `WSAStartup` → `socket(AF_INET,
    SOCK_STREAM)` → bind/listen/accept → non-blocking `select`/`recv`/`send`.
  - Public interface (`init`/`update`/`close`/`send_response`/`on_request_callback`)
    is unchanged, so `commands.lua` / `jsonrpc.lua` are untouched.
  - Port overridable via `BALATRO_BRIDGE_PORT` (default 37651).
- `mcp/src/bridge/protocol.ts`
  - Add `DEFAULT_BRIDGE_PORT` (37651) and `DEFAULT_BRIDGE_HOST` so the Node
    client and Lua mod agree on the default.
- `mcp/src/bridge/socket-client.ts`
  - Select transport by `process.platform`: TCP loopback on Windows, Unix
    socket elsewhere. Port injectable via `new BridgeClient({ port })`.
- `mcp/src/index.ts`
  - Start the bridge connection in the background so the MCP server stays
    alive when Balatro is not yet running; `BridgeClient` keeps retrying and
    tools return `GAME_NOT_RUNNING` until the game comes online. This makes
    the server usable as a persistent MCP plugin (e.g. in a desktop client)
    that auto-connects when Balatro launches.
- `scripts/setup-windows.ps1` (new)
  - Windows helper mirroring the macOS Makefile targets: `doctor`,
    `install-mods`, `build`, `all`. Auto-detects Steam library folders via
    `libraryfolders.vdf`.
- `.gitignore`
  - Ignore local Reasonix / `.mcp.json` environment files.

## Testing

Verified end-to-end on a real **Balatro Steam Windows build**:

- `pnpm typecheck` and `pnpm build` pass.
- All Lua files pass LuaJIT syntax validation.
- With the mod loaded, the game listens on `127.0.0.1:37651`; the Node
  `BridgeClient` connects over TCP loopback and drives the full JSON-RPC
  protocol (`get_state`, `select_blind`, `select_hand_cards`, `play_hand`,
  `discard_hand`, shop/booster/consumable tools, `cash_out`).
- Played a complete run to Ante 4 against a real game instance confirming
  transport stability over a long session.

Note: the Windows backend is exercised against the real game; the macOS
backend is preserved as-is and was not modified.