### PR TITLE
feat: add opening rerolls and sticker upkeep

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,12 @@ The server and the mod find each other at `/tmp/balatro-mcp.sock` on macOS and L
 
 ## What the agent can do
 
-The agent has 22 tools available.
+The agent has 24 tools available.
 
 | Area | Tools |
 | --- | --- |
 | Inspect the game | `balatro_inspect_game_state`, `balatro_inspect_card_instance` |
+| Run control | `balatro_start_run`, `balatro_restart_run` |
 | Blinds | `balatro_select_blind`, `balatro_skip_blind` |
 | Hand | `balatro_select_hand_cards`, `balatro_sort_hand`, `balatro_play_hand`, `balatro_discard_hand` |
 | Shop | `balatro_buy_card`, `balatro_buy_consumable`, `balatro_buy_voucher`, `balatro_buy_booster`, `balatro_reroll_shop`, `balatro_leave_shop`, `balatro_cash_out` |

--- a/README.zh.md
+++ b/README.zh.md
@@ -72,11 +72,12 @@ MCP 客户端 ── stdio ──> Bun 服务器 ── JSON-RPC 2.0 / NDJSON �
 
 ## 智能体可以做什么
 
-智能体有 22 个工具可用。
+智能体有 24 个工具可用。
 
 | 范围 | 工具 |
 | --- | --- |
 | 检查游戏 | `balatro_inspect_game_state`, `balatro_inspect_card_instance` |
+| 对局控制 | `balatro_start_run`, `balatro_restart_run` |
 | 盲注 | `balatro_select_blind`, `balatro_skip_blind` |
 | 手牌 | `balatro_select_hand_cards`, `balatro_sort_hand`, `balatro_play_hand`, `balatro_discard_hand` |
 | 商店 | `balatro_buy_card`, `balatro_buy_consumable`, `balatro_buy_voucher`, `balatro_buy_booster`, `balatro_reroll_shop`, `balatro_leave_shop`, `balatro_cash_out` |

--- a/mcp/src/prompts/strategy.md
+++ b/mcp/src/prompts/strategy.md
@@ -16,6 +16,7 @@ Use `balatro_list_game_entities` to read entity prototypes from the running game
 - Issue actions through the typed bridge tools (e.g. `balatro_play_hand`, `balatro_discard_hand`, `balatro_buy_card`, `balatro_skip_blind`). Use `card_id` for live card actions, not `entity_id`.
 - Shared bridge errors: `GAME_NOT_RUNNING` means no Balatro instance is connected, `INSTANCE_BUSY` means another MCP client owns the bridge, and `PROTOCOL_MISMATCH` means the TypeScript server and Balatro mod versions are incompatible. Treat these as hard stops — do not fabricate state or outcomes.
 - Do not replay an action tool call unless the bridge explicitly reports it was lost or failed.
+- At MENU or GAME_OVER, `balatro_start_run` can start an unlocked supported deck and stake. `balatro_restart_run` is an opening-tag reroll that preserves the current setup and is legal only at Ante 1 before the Small Blind is played or skipped. Use opening rerolls only when the user explicitly requests them; never loop until an ideal tag appears by default.
 
 ### Tactical Checks
 
@@ -24,6 +25,7 @@ Use `balatro_list_game_entities` to read entity prototypes from the running game
 - Do not routinely finish a difficult round with all discards unused. Red Deck's extra discard is a resource for finding the build-defining hand, especially when the current hand cannot meet the Blind in the remaining plays.
 - During blind selection, inspect `blind_selection` and its `skip_reward` before deciding. Boss Blinds cannot be skipped. Skip Small or Big blinds only when the tag's concrete value and tempo exceed the lost blind reward, shop access, and scaling opportunities.
 - Joker order is gameplay-relevant because scoring resolves left to right. In general, put additive Chips/Mult before xMult, and position Blueprint, Brainstorm, or other copy effects against the intended target before playing.
+- Treat Joker stickers as economic and slot constraints. Eternal Jokers cannot be sold. Perishable Jokers expose their remaining active rounds and should usually be sold after becoming debuffed when the slot is needed. Each Rental Joker charges its displayed cost every round; add the per-card costs together before buying or retaining several rentals.
 
 ### Reasoning Style
 

--- a/mcp/src/tools/actions.ts
+++ b/mcp/src/tools/actions.ts
@@ -13,6 +13,7 @@ import LEAVE_SHOP_DESCRIPTION from "./descriptions/leave-shop.txt" with { type: 
 import PLAY_HAND_DESCRIPTION from "./descriptions/play-hand.txt" with { type: "text" }
 import REORDER_JOKERS_DESCRIPTION from "./descriptions/reorder-jokers.txt" with { type: "text" }
 import REROLL_SHOP_DESCRIPTION from "./descriptions/reroll-shop.txt" with { type: "text" }
+import RESTART_RUN_DESCRIPTION from "./descriptions/restart-run.txt" with { type: "text" }
 import SELECT_BLIND_DESCRIPTION from "./descriptions/select-blind.txt" with { type: "text" }
 import SELECT_BOOSTER_CARD_DESCRIPTION from "./descriptions/select-booster-card.txt" with { type: "text" }
 import SELECT_HAND_CARDS_DESCRIPTION from "./descriptions/select-hand-cards.txt" with { type: "text" }
@@ -20,6 +21,7 @@ import SELL_CARD_DESCRIPTION from "./descriptions/sell-card.txt" with { type: "t
 import SKIP_BLIND_DESCRIPTION from "./descriptions/skip-blind.txt" with { type: "text" }
 import SKIP_BOOSTER_DESCRIPTION from "./descriptions/skip-booster.txt" with { type: "text" }
 import SORT_HAND_DESCRIPTION from "./descriptions/sort-hand.txt" with { type: "text" }
+import START_RUN_DESCRIPTION from "./descriptions/start-run.txt" with { type: "text" }
 import USE_CONSUMABLE_DESCRIPTION from "./descriptions/use-consumable.txt" with { type: "text" }
 
 const emptySchema = z.object({}).strict()
@@ -62,6 +64,16 @@ const reorderJokersSchema = z
       .array(cardIdSchema)
       .max(50)
       .describe("All held Joker IDs in the desired left-to-right scoring order."),
+  })
+  .strict()
+const startRunSchema = z
+  .object({
+    deck: z
+      .enum(["red", "blue", "yellow", "green", "black"])
+      .describe("Unlocked base deck to use."),
+    stake: z
+      .enum(["white", "red", "green", "black", "blue", "purple", "orange", "gold"])
+      .describe("Unlocked stake difficulty to use."),
   })
   .strict()
 const buyConsumableSchema = z
@@ -114,6 +126,13 @@ interface ActionTool {
 }
 
 const NO_ARG_TOOLS: ActionTool[] = [
+  {
+    name: "balatro_restart_run",
+    title: "Restart Opening Run",
+    description: RESTART_RUN_DESCRIPTION,
+    command: "restart_run",
+    annotations: annotations(true, false),
+  },
   {
     name: "balatro_select_blind",
     title: "Select Blind",
@@ -205,6 +224,18 @@ const CARD_ID_TOOLS: ActionTool[] = [
 ]
 
 export function registerActionTools(server: McpServer, bridge: BridgeClient): void {
+  server.registerTool(
+    "balatro_start_run",
+    {
+      title: "Start Run",
+      description: START_RUN_DESCRIPTION,
+      inputSchema: startRunSchema,
+      outputSchema: commandOutputSchema,
+      annotations: annotations(true, false),
+    },
+    ({ deck, stake }) => commandResult(bridge, "start_run", { deck, stake }),
+  )
+
   for (const tool of NO_ARG_TOOLS) {
     server.registerTool(
       tool.name,

--- a/mcp/src/tools/descriptions/restart-run.txt
+++ b/mcp/src/tools/descriptions/restart-run.txt
@@ -1,0 +1,1 @@
+Rerolls the current unseeded run while preserving its deck and stake, generating new opening Blind tags. This destructive action is available only at Ante 1 on the initial Small Blind selection before any Blind is played or skipped. Use it only when the user explicitly asks to reroll the opening; do not repeatedly fish for ideal tags by default.

--- a/mcp/src/tools/descriptions/start-run.txt
+++ b/mcp/src/tools/descriptions/start-run.txt
@@ -1,0 +1,1 @@
+Starts a new unseeded run with one supported base deck and stake. Use this only from MENU or GAME_OVER after confirming the requested setup. The deck and stake must already be unlocked. This replaces any finished or abandoned run state.

--- a/mcp/src/tools/inspectGameState.ts
+++ b/mcp/src/tools/inspectGameState.ts
@@ -212,13 +212,31 @@ function displayJokerPrice(card: Record<string, unknown>): string | undefined {
   return `$${String(card.cost ?? "?")}/$${String(card.sell_value ?? "?")}`
 }
 
+function displayJokerStickers(card: Record<string, unknown>): string[] {
+  if (!Array.isArray(card.stickers)) return []
+  return card.stickers.map((sticker) => {
+    if (sticker === "eternal") return "Eternal"
+    if (sticker === "perishable") {
+      const rounds = card.perishable_rounds_remaining
+      return rounds === undefined ? "Perishable" : `Perishable (${String(rounds)} rounds left)`
+    }
+    if (sticker === "rental") {
+      const cost = card.rental_cost_per_round
+      return cost === undefined ? "Rental" : `Rental (-$${String(cost)}/round)`
+    }
+    return String(sticker)
+  })
+}
+
 function displayJokerLine(card: Record<string, unknown>, index: number): string {
   const rarity = displayJokerRarity(card.rarity)
   const price = displayJokerPrice(card)
   const edition = displayCardModifier(card.edition, EDITION_NAMES)
-  const status = [edition, card.debuffed !== undefined ? "(x)" : undefined].filter(
-    (value): value is string => value !== undefined,
-  )
+  const status = [
+    edition,
+    ...displayJokerStickers(card),
+    card.debuffed === true ? "(debuffed)" : undefined,
+  ].filter((value): value is string => value !== undefined)
   const parts = [
     `${index}. [${String(card.card_id ?? "?")}]`,
     `${displayJokerName(card)}${rarity}`,
@@ -426,6 +444,12 @@ function stateToMarkdown(data: object): string {
   if (phase) lines.push(`**Phase:** ${phase}  `)
   if (payload.g_state) lines.push(`**G.STATE:** ${String(payload.g_state)}  `)
   if (payload.money !== undefined) lines.push(`**Money:** $${payload.money}  `)
+  const runSetup = asRecord(payload.run_setup)
+  if (runSetup) {
+    lines.push(
+      `**Run Setup:** ${String(runSetup.deck ?? "unknown")} / ${String(runSetup.stake ?? runSetup.stake_level ?? "unknown")}  `,
+    )
+  }
   lines.push("")
 
   if (payload.ante !== undefined || payload.current_round !== undefined) {
@@ -474,6 +498,12 @@ function stateToMarkdown(data: object): string {
         appendCompactCardLine(lines, joker, index)
         index += 1
       }
+    }
+    const upkeep = asRecord(payload.joker_upkeep)
+    if (upkeep?.rental_total_per_round !== undefined) {
+      lines.push(
+        `- **Rental upkeep:** ${String(upkeep.rental_count ?? "?")} Joker(s), -$${String(upkeep.rental_total_per_round)}/round`,
+      )
     }
     lines.push("")
   }

--- a/mods/balatro_mcp/src/actions.lua
+++ b/mods/balatro_mcp/src/actions.lua
@@ -212,6 +212,67 @@ local function purchase_from_shop(card, buy_and_use)
   return nil
 end
 
+local RUN_DECKS = {
+  red = 'b_red',
+  blue = 'b_blue',
+  yellow = 'b_yellow',
+  green = 'b_green',
+  black = 'b_black',
+}
+
+local RUN_STAKES = {
+  white = { key = 'stake_white', level = 1 },
+  red = { key = 'stake_red', level = 2 },
+  green = { key = 'stake_green', level = 3 },
+  black = { key = 'stake_black', level = 4 },
+  blue = { key = 'stake_blue', level = 5 },
+  purple = { key = 'stake_purple', level = 6 },
+  orange = { key = 'stake_orange', level = 7 },
+  gold = { key = 'stake_gold', level = 8 },
+}
+
+local function begin_run(deck_name, stake_name, restarted)
+  local deck_key = RUN_DECKS[deck_name]
+  local stake = RUN_STAKES[stake_name]
+  if not deck_key or not stake then
+    return err('INVALID_TARGET', 'Unsupported deck or stake')
+  end
+
+  local profile = G.PROFILES and G.SETTINGS and G.PROFILES[G.SETTINGS.profile]
+  local deck = G.P_CENTERS and G.P_CENTERS[deck_key]
+  if not profile or not deck or not G.GAME then
+    return err('INVALID_TARGET', 'Run setup data is not available')
+  end
+  if not deck.unlocked and not profile.all_unlocked then
+    return err('INVALID_TARGET', 'Deck is not unlocked: ' .. deck_key)
+  end
+  if SMODS and SMODS.stake_is_unlocked
+      and not SMODS.stake_is_unlocked(stake.key, deck_key) then
+    return err('INVALID_TARGET', 'Stake ' .. stake.key .. ' is not unlocked for ' .. deck_key)
+  end
+  if not Back or not G.FUNCS or not G.FUNCS.start_run then
+    return err('INTERNAL_ERROR', 'Balatro run-start callbacks are unavailable')
+  end
+
+  if G.OVERLAY_MENU and G.FUNCS.exit_overlay_menu then G.FUNCS.exit_overlay_menu() end
+  G.GAME.viewed_back = Back(deck)
+  profile.MEMORY = profile.MEMORY or {}
+  profile.MEMORY.deck = deck.name
+  profile.MEMORY.stake = stake.level
+  G.SETTINGS.current_setup = 'New Run'
+  G.FUNCS.start_run(nil, { stake = stake.level })
+
+  return ok({
+    started = true,
+    restarted = restarted or nil,
+    deck = deck_name,
+    deck_key = deck_key,
+    stake = stake_name,
+    stake_key = stake.key,
+    stake_level = stake.level,
+  })
+end
+
 local PACK_PHASES = {
   "TAROT_PACK",
   "PLANET_PACK",
@@ -220,6 +281,46 @@ local PACK_PHASES = {
   "BUFFOON_PACK",
   "SMODS_BOOSTER_OPENED",
 }
+
+handlers.start_run = function(args)
+  local phase_err = check_phase({ 'MENU', 'GAME_OVER' })
+  if phase_err then return phase_err end
+  return begin_run(args.deck, args.stake, false)
+end
+
+handlers.restart_run = function(args)
+  local phase_err = check_phase({ 'BLIND_SELECT' })
+  if phase_err then return phase_err end
+
+  local round_resets = G.GAME and G.GAME.round_resets
+  if not round_resets or round_resets.ante ~= 1 or G.GAME.blind_on_deck ~= 'Small' then
+    return err(
+      'WRONG_PHASE',
+      'Opening rerolls are only allowed at Ante 1 before the Small Blind is played or skipped'
+    )
+  end
+  if G.GAME.seeded or G.GAME.challenge then
+    return err('INVALID_TARGET', 'Opening rerolls are only supported for standard unseeded runs')
+  end
+
+  local selected_back = G.GAME.selected_back
+  local selected_center = selected_back and selected_back.effect and selected_back.effect.center
+  local current_deck_key = selected_center and selected_center.key
+  local current_deck_name
+  for deck_name, deck_key in pairs(RUN_DECKS) do
+    if deck_key == current_deck_key then current_deck_name = deck_name end
+  end
+
+  local current_stake_name
+  for stake_name, stake in pairs(RUN_STAKES) do
+    if stake.level == G.GAME.stake then current_stake_name = stake_name end
+  end
+  if not current_deck_name or not current_stake_name then
+    return err('INVALID_TARGET', 'The current deck or stake is not supported for opening rerolls')
+  end
+
+  return begin_run(current_deck_name, current_stake_name, true)
+end
 
 handlers.select_blind = function(args)
   local phase_err = check_phase({ "BLIND_SELECT" })

--- a/mods/balatro_mcp/src/state.lua
+++ b/mods/balatro_mcp/src/state.lua
@@ -68,6 +68,16 @@ local function get_card_stickers(card)
   return stickers
 end
 
+local function get_perishable_rounds_remaining(card)
+  if not card or not card.ability or not card.ability.perishable then return nil end
+  return tonumber(card.ability.perish_tally)
+end
+
+local function get_rental_cost_per_round(card)
+  if not card or not card.ability or not card.ability.rental then return nil end
+  return G and G.GAME and tonumber(G.GAME.rental_rate) or 3
+end
+
 local function get_card_edition(card)
   if not card or not card.edition then return nil end
   local ed = card.edition
@@ -225,6 +235,8 @@ local function serialize_joker(card)
     sell_value = card.sell_cost,
     edition = get_card_edition(card),
     stickers = get_card_stickers(card),
+    perishable_rounds_remaining = get_perishable_rounds_remaining(card),
+    rental_cost_per_round = get_rental_cost_per_round(card),
     debuffed = card.debuff or nil,
     cost = card.cost,
   }
@@ -285,6 +297,8 @@ local function serialize_shop_card(card)
     sell_value = card.sell_cost,
     edition = get_card_edition(card),
     stickers = get_card_stickers(card),
+    perishable_rounds_remaining = get_perishable_rounds_remaining(card),
+    rental_cost_per_round = get_rental_cost_per_round(card),
   }
 end
 
@@ -346,6 +360,15 @@ local function compute_legal_actions()
     local blind_ui = blind_key and G.blind_select_opts and G.blind_select_opts[string.lower(blind_key)]
     local select_button = blind_ui and blind_ui.get_UIE_by_ID and blind_ui:get_UIE_by_ID('select_blind_button')
     local round_resets = G.GAME and G.GAME.round_resets
+    local selected_back = G.GAME and G.GAME.selected_back
+    local selected_center = selected_back and selected_back.effect and selected_back.effect.center
+    local basic_decks = { b_red = true, b_blue = true, b_yellow = true, b_green = true, b_black = true }
+    if round_resets and round_resets.ante == 1 and blind_key == 'Small'
+        and selected_center and basic_decks[selected_center.key]
+        and not G.GAME.seeded and not G.GAME.challenge
+        and G.GAME.stake and G.GAME.stake >= 1 and G.GAME.stake <= 8 then
+      actions[#actions + 1] = 'restart_run'
+    end
     if G.GAME and G.GAME.round_resets and G.GAME.round_resets.blind_choices
         and (blind_key == 'Small' or blind_key == 'Big' or blind_key == 'Boss')
         and G.GAME.round_resets.blind_choices[blind_key]
@@ -358,6 +381,8 @@ local function compute_legal_actions()
         actions[#actions + 1] = 'skip_blind'
       end
     end
+  elseif gs == states.MENU or gs == states.GAME_OVER then
+    actions[#actions + 1] = 'start_run'
   elseif gs == states.SHOP then
     local has_card = false
     local has_consumable = false
@@ -613,6 +638,17 @@ local function snapshot()
   payload.bankrupt_at = G.GAME and G.GAME.bankrupt_at
   payload.ante = G.GAME and G.GAME.round_resets and G.GAME.round_resets.ante
 
+  local selected_back = G.GAME and G.GAME.selected_back
+  local selected_center = selected_back and selected_back.effect and selected_back.effect.center
+  if selected_center and selected_center.key then
+    payload.run_setup = {
+      deck = selected_center.key,
+      stake_level = G.GAME.stake,
+      stake = G.GAME.stake and SMODS and SMODS.stake_from_index
+          and SMODS.stake_from_index(G.GAME.stake) or nil,
+    }
+  end
+
   if G.GAME and G.GAME.blind then
     local b = G.GAME.blind
     payload.blind = {
@@ -658,13 +694,26 @@ local function snapshot()
 
   if G.jokers and G.jokers.cards then
     local jokers = {}
+    local rental_count = 0
+    local rental_total_per_round = 0
     for _, card in ipairs(G.jokers.cards) do
       local set = card and card.config and card.config.center and card.config.center.set
       if set == nil or set == 'Joker' then
         jokers[#jokers + 1] = serialize_joker(card)
+        local rental_cost = get_rental_cost_per_round(card)
+        if rental_cost then
+          rental_count = rental_count + 1
+          rental_total_per_round = rental_total_per_round + rental_cost
+        end
       end
     end
     if #jokers > 0 then payload.jokers = jokers end
+    if rental_count > 0 then
+      payload.joker_upkeep = {
+        rental_count = rental_count,
+        rental_total_per_round = rental_total_per_round,
+      }
+    end
   end
 
   if G.consumeables and G.consumeables.cards then


### PR DESCRIPTION
## Summary

- add typed tools to start an unlocked base-deck run and safely reroll its opening Blind tags
- restrict opening rerolls to a standard unseeded Ante 1 run before the Small Blind is played or skipped, while preserving deck and stake
- expose Eternal, Perishable, and Rental Joker state, including remaining Perishable rounds and total Rental upkeep
- document the new run controls and sticker strategy constraints

## Why

Agents could not autonomously choose a supported run setup or reroll opening tags. Joker state also omitted information needed to manage high-stake sticker constraints: Eternal Jokers were not shown in the Markdown state, Perishable Jokers had no remaining-round display, and multiple Rental Jokers had no aggregate upkeep total.

## Validation

- `bun run typecheck`
- `bun run build`
- `oxfmt --check` on the changed MCP TypeScript and strategy files
- live Balatro smoke test on Windows: started Blue Deck at Gold Stake, rerolled into different Small/Big Blind tags and Boss while preserving deck/stake, then confirmed a reroll after selecting the Small Blind returns `WRONG_PHASE`

