### PR TITLE
fix(mod): gate new_game to the main menu; validate Lua with LuaJIT in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,8 @@ jobs:
       - name: Validate Lua
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends lua5.4
-          find mod -name '*.lua' -print0 | xargs -0 -n1 luac5.4 -p
+          sudo apt-get install -y --no-install-recommends luajit
+          find mod -name '*.lua' -exec luajit -b {} /dev/null \;
 
       - name: Package mod
         run: |

--- a/mod/src/actions.lua
+++ b/mod/src/actions.lua
@@ -703,7 +703,11 @@ handlers.continue_game = function(args)
 end
  
 handlers.new_game = function(args)
-  if not G or not G.GAME then
+  if not G or not G.STAGE or not G.STAGES or G.STAGE ~= G.STAGES.MAIN_MENU
+      or not G.STATE or not G.STATES or G.STATE ~= G.STATES.MENU then
+    return err("WRONG_PHASE", "New game is only available from the main menu")
+  end
+  if not G.GAME then
     return err("GAME_NOT_RUNNING", "Game not ready")
   end
   if not G.FUNCS or type(G.FUNCS.start_setup_run) ~= "function" then

--- a/mod/src/state.lua
+++ b/mod/src/state.lua
@@ -507,7 +507,7 @@ local function compute_legal_actions()
   if G.STAGE == G.STAGES.RUN and G.GAME then
     actions[#actions + 1] = 'restart'
   end
-  if G.GAME then
+  if G.STAGE == G.STAGES.MAIN_MENU and gs == states.MENU then
     actions[#actions + 1] = 'new_game'
   end
   return actions


### PR DESCRIPTION
Two small fixes from a review pass over the v0.1.0 codebase.

### 1. `fix(mod): gate new_game to the main menu`

`balatro_new_game` became callable and listed as a legal action at any time again (including mid-run) after the v0.1.0 history rewrite; an agent could wipe an active run with no warning (`restart` already covers in-run restarts). This restores the menu-only gate on both the handler (`WRONG_PHASE` outside the main menu) and `legal_actions`.

### 2. `ci(mod): validate mod Lua with LuaJIT`

The release workflow validated `mod/` Lua with `luac5.4`, but the mod runs on LuaJIT (Lua 5.1). Lua 5.4's parser accepts 5.3+/5.4-only syntax (`//`, bitwise operators, `local x <const>`, and similar) that would crash in-game while CI stayed green. The workflow now compiles each file with `luajit -b`.

## Noted but left unfixed

- `resources/live.ts` reports phase-unavailable resources with `ProtocolErrorCode.InvalidParams`; the `data.error_code: "UNAVAILABLE"` already gives clients a stable code, but the top-level code is semantically off.
- The live `balatro://` resources have no tests after `inspectGameState.test.ts` was removed during the rewrite.
- `postgame.ts` hand-rolls YAML frontmatter parsing; titles/summaries containing colons will be truncated.
- `readPostgame(index)` joins the index into a path without validating it (currently safe because the resource layer validates first).
- `mod/main.lua` still logs "Loaded Balatro MCP Dev Mod" after the mod rename.
