### PR TITLE
ci(mod): validate mod Lua with LuaJIT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,8 @@ jobs:
       - name: Validate Lua
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends lua5.4
-          find mod -name '*.lua' -print0 | xargs -0 -n1 luac5.4 -p
+          sudo apt-get install -y --no-install-recommends luajit
+          find mod -name '*.lua' -exec luajit -b {} /dev/null \;
 
       - name: Package mod
         run: |


### PR DESCRIPTION
`mod/` runs on LuaJIT (Lua 5.1), but the release workflow validates it with `luac5.4`. Lua 5.4's parser accepts 5.3+/5.4-only syntax (`//`, bitwise operators, `local x <const>`, and similar) that would crash in-game while CI stays green, and it can also reject valid LuaJIT/Lua 5.1 constructs.

This switches the "Validate Lua" step to compile each file with `luajit -b`, the actual runtime, so the check matches what the game executes.
